### PR TITLE
fixed issue 3 file permissions not maintained

### DIFF
--- a/internal/controllers/repo/repo.go
+++ b/internal/controllers/repo/repo.go
@@ -166,7 +166,12 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) error {
 	e.rec.Eventf(cr, corev1.EventTypeNormal, "RepoSyncSuccess",
 		"Origin and target repo synchronized")
 
-	commitId, err := toRepo.Commit(".", "first commit")
+	toPath := helpers.String(spec.ToRepo.Path)
+	commitId, err := toRepo.Commit(".", "first commit", &git.IndexOptions{
+		OriginRepo: fromRepo,
+		FromPath:   fromPath,
+		ToPath:     toPath,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem**
After copy to toRepo file with non-standard permissions are pushed with standard permissions (default filemode is 644).

**Context**
[go-git](https://github.com/go-git/go-git) manage cloned repos with [go-billy](https://github.com/go-git/go-billy) filesystem interface and the copy of files is performed reading the content of the file and creating another file with the same content. This operation causes the destination file to lose non-standard permissions setted in the original file.
The go-bully library has not yet implemented the chmod function so is not possible to change permissions on the newly created file.

**Solution**
Filemode are stored by git using an index that contains informations about the files (even file mode) after the staging.
go-git provide functions to manage [IndexStorage](https://github.com/go-git/go-git/blob/72ce9961c676b73c9bdd0678b64af7b0a42253f8/storage/memory/storage.go#L68). The idea is to update the filemode of each staged file of the new repo according to the filemode of the corrisponding file in the original repo.

