### PR TITLE
feat: support templating also on file name

### DIFF
--- a/internal/controllers/repo/copier.go
+++ b/internal/controllers/repo/copier.go
@@ -12,17 +12,26 @@ import (
 )
 
 type copier struct {
-	fromRepo       *git.Repo
-	toRepo         *git.Repo
-	originCopyPath string
-	targetCopyPath string
-	renderFunc     func(in io.Reader, out io.Writer) error
-	krateoIgnore   *gi.GitIgnore
-	targetIgnore   *gi.GitIgnore
+	fromRepo        *git.Repo
+	toRepo          *git.Repo
+	originCopyPath  string
+	targetCopyPath  string
+	renderFunc      func(in io.Reader, out io.Writer) error
+	renderFileNames func(src string) (string, error)
+	krateoIgnore    *gi.GitIgnore
+	targetIgnore    *gi.GitIgnore
 }
 
 func (co *copier) copyFile(src, dst string, doNotRender bool) (err error) {
 	fromFS, toFS := co.fromRepo.FS(), co.toRepo.FS()
+
+	if !doNotRender && co.renderFileNames != nil {
+		var err error
+		dst, err = co.renderFileNames(dst)
+		if err != nil {
+			return err
+		}
+	}
 
 	in, err := fromFS.Open(src)
 	if err != nil {

--- a/internal/controllers/repo/repo.go
+++ b/internal/controllers/repo/repo.go
@@ -262,7 +262,7 @@ func (e *external) SyncRepos(ctx context.Context, cr *repov1alpha1.Repo, commitM
 				"Unable to load '.krateoignore' file: %s", err.Error())
 		}
 
-		createRenderFunc(co, values)
+		createRenderFuncs(co, values)
 
 		toPath := helpers.String(spec.ToRepo.Path)
 		if len(toPath) == 0 {
@@ -335,7 +335,7 @@ func (e *external) SyncRepos(ctx context.Context, cr *repov1alpha1.Repo, commitM
 	return nil
 }
 
-func createRenderFunc(co *copier, values interface{}) {
+func createRenderFuncs(co *copier, values interface{}) {
 	co.renderFunc = func(in io.Reader, out io.Writer) error {
 		bin, err := io.ReadAll(in)
 		if err != nil {
@@ -348,6 +348,14 @@ func createRenderFunc(co *copier, values interface{}) {
 
 		return tmpl.FRender(out, values)
 	}
+	co.renderFileNames = func(src string) (string, error) {
+		tmpl, err := mustache.ParseString(src)
+		if err != nil {
+			return "", err
+		}
+		return tmpl.Render(values)
+	}
+
 }
 
 func loadIgnoreFileEventually(co *copier) error {


### PR DESCRIPTION
> **Is your feature request related to a problem? Please describe.** #24 
> Requested the possibility to template also filename before copying. eg /app/index-{{testTemplate}}.html -> /app/index-tplKrateo.html

**Implementation details**
- Added the templating of filenames. Note that you should template the file name with a pattern supported by the filesystem like `{{filename}}.md`