### PR TITLE
Make target repo ignore file optional

### DIFF
--- a/internal/controllers/repo/repo.go
+++ b/internal/controllers/repo/repo.go
@@ -268,9 +268,11 @@ func (e *external) SyncRepos(ctx context.Context, cr *repov1alpha1.Repo, commitM
 
 		err = loadIgnoreTargetFiles(ptr.StringFromPtr(spec.ToRepo.Path), co)
 		if err != nil {
-			return fmt.Errorf("unable to load ignore target files: %w", err)
+			e.log.Info("Unable to load ignore target files", "msg", err.Error())
+			e.rec.Eventf(cr, corev1.EventTypeWarning, "CannotLoadIgnoreFile",
+				"Unable to load ignore target files: %s", err.Error())
 		}
-
+		
 		if err := loadIgnoreFileEventually(co); err != nil {
 			e.log.Info("Unable to load '.krateoignore'", "msg", err.Error())
 			e.rec.Eventf(cr, corev1.EventTypeWarning, "CannotLoadIgnoreFile",


### PR DESCRIPTION
Make existence of a ignore file into the target repo optional.

The current implementation requires to target repo to already contain a ignore file in order to perform the sync.
If the ignore file is not present the sync is not performed.

This change makes the presence of an ignore file in the target repository optional (it will just rise a warning if not present).